### PR TITLE
Change order of fmt.Println and http.ListenAndServe

### DIFF
--- a/01-Authorization-RS256/main.go
+++ b/01-Authorization-RS256/main.go
@@ -47,8 +47,8 @@ func main() {
 
 	})))
 
-	http.ListenAndServe(":3001", r)
 	fmt.Println("Listening on http://localhost:3001")
+	http.ListenAndServe(":3001", r)
 }
 
 func checkJwt(h http.Handler) http.Handler {


### PR DESCRIPTION
Otherwise fmt.Println only prints AFTER http server has stopped listening