### PR TITLE
Add notice to Go API Sample for 3rd Party Vulnerability

### DIFF
--- a/01-Authorization-RS256/README.md
+++ b/01-Authorization-RS256/README.md
@@ -1,5 +1,7 @@
 # Golang Authorization for RS256-Signed Tokens
 
+> :warning:  **Important security note:** This solution uses a 3rd party library with an unresolved [security issue](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2020-26160). Please review the details of the vulnerability, including any of the documented mitigations, before implementing the solution.
+
 This sample demonstrates how to protect endpoints in a Go API by verifying an incoming JWT access token signed by Auth0. The token must be signed with the RS256 algorithm and must be verified against your Auth0 JSON Web Key Set.
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Auth0 Golang API Samples
 
+> :warning:  **Important security note:** This solution uses a 3rd party library with an unresolved [security issue](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2020-26160). Please review the details of the vulnerability, including any of the documented mitigations, before implementing the solution.
+
 [![CircleCI](https://img.shields.io/circleci/project/github/auth0-samples/auth0-golang-api-samples.svg?style=flat-square)](https://circleci.com/gh/auth0-samples/auth0-golang-api-samples/tree/master)
 
 These samples demonstrate how to create an API with Go which only permits access to resources if a valid **access token** is included. This verification is done by validating the signature and claims in a JSON Web Token (JWT) signed by Auth0.


### PR DESCRIPTION
The 3rd party library `jwt-go` contains an unresolved security issue, as captured in [CVE-2020-26160](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2020-26160). This change adds a warning informing readers of this vulnerability and any mitigations available, contained on the linked CVE.

Accompanies https://github.com/auth0/docs/pull/9562
