### PR TITLE
[SDK-2848] Reorganize code into packages

### DIFF
--- a/01-Authorization-RS256/main.go
+++ b/01-Authorization-RS256/main.go
@@ -1,70 +1,19 @@
 package main
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
 	"log"
 	"net/http"
-	"os"
-	"strings"
 
-	jwtmiddleware "github.com/auth0/go-jwt-middleware"
-	"github.com/codegangsta/negroni"
-	"github.com/form3tech-oss/jwt-go"
-	"github.com/gorilla/mux"
 	"github.com/joho/godotenv"
 	"github.com/rs/cors"
+
+	"01-Authorization-RS256/router"
 )
 
-type Response struct {
-	Message string `json:"message"`
-}
-
-type Jwks struct {
-	Keys []JSONWebKeys `json:"keys"`
-}
-
-type JSONWebKeys struct {
-	Kty string   `json:"kty"`
-	Kid string   `json:"kid"`
-	Use string   `json:"use"`
-	N   string   `json:"n"`
-	E   string   `json:"e"`
-	X5c []string `json:"x5c"`
-}
-
 func main() {
-	err := godotenv.Load()
-	if err != nil {
+	if err := godotenv.Load(); err != nil {
 		log.Print("Error loading .env file")
 	}
-
-	jwtMiddleware := jwtmiddleware.New(jwtmiddleware.Options{
-		ValidationKeyGetter: func(token *jwt.Token) (interface{}, error) {
-			// Verify 'aud' claim
-			aud := os.Getenv("AUTH0_AUDIENCE")
-			checkAud := token.Claims.(jwt.MapClaims).VerifyAudience(aud, false)
-			if !checkAud {
-				return token, errors.New("Invalid audience.")
-			}
-			// Verify 'iss' claim
-			iss := "https://" + os.Getenv("AUTH0_DOMAIN") + "/"
-			checkIss := token.Claims.(jwt.MapClaims).VerifyIssuer(iss, false)
-			if !checkIss {
-				return token, errors.New("Invalid issuer.")
-			}
-
-			cert, err := getPemCert(token)
-			if err != nil {
-				panic(err.Error())
-			}
-
-			result, _ := jwt.ParseRSAPublicKeyFromPEM([]byte(cert))
-			return result, nil
-		},
-		SigningMethod: jwt.SigningMethodRS256,
-	})
 
 	c := cors.New(cors.Options{
 		AllowedOrigins:   []string{"http://localhost:3000"},
@@ -72,111 +21,11 @@ func main() {
 		AllowedHeaders:   []string{"Authorization"},
 	})
 
-	r := mux.NewRouter()
-
-	// This route is always accessible
-	r.Handle("/api/public", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		message := "Hello from a public endpoint! You don't need to be authenticated to see this."
-		responseJSON(message, w, http.StatusOK)
-	}))
-
-	// This route is only accessible if the user has a valid access_token
-	// We are chaining the jwtmiddleware middleware into the negroni handler function which will check
-	// for a valid token.
-	r.Handle("/api/private", negroni.New(
-		negroni.HandlerFunc(jwtMiddleware.HandlerWithNext),
-		negroni.Wrap(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			message := "Hello from a private endpoint! You need to be authenticated to see this."
-			responseJSON(message, w, http.StatusOK)
-		}))))
-
-	// This route is only accessible if the user has a valid access_token with the read:messages scope
-	// We are chaining the jwtmiddleware middleware into the negroni handler function which will check
-	// for a valid token and scope.
-	r.Handle("/api/private-scoped", negroni.New(
-		negroni.HandlerFunc(jwtMiddleware.HandlerWithNext),
-		negroni.Wrap(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			token := r.Context().Value("user").(*jwt.Token)
-
-			hasScope := checkScope("read:messages", token)
-			if !hasScope {
-				message := "Insufficient scope."
-				responseJSON(message, w, http.StatusForbidden)
-				return
-			}
-
-			message := "Hello from a private endpoint! You need to be authenticated to see this."
-			responseJSON(message, w, http.StatusOK)
-		}))))
-
+	r := router.New()
 	handler := c.Handler(r)
-	http.Handle("/", r)
-	fmt.Println("Listening on http://localhost:3010")
-	http.ListenAndServe("0.0.0.0:3010", handler)
-}
 
-func checkScope(scope string, token *jwt.Token) bool {
-	claims, ok := token.Claims.(jwt.MapClaims)
-	if !ok {
-		return false
+	log.Print("Server listening on http://localhost:3010")
+	if err := http.ListenAndServe("0.0.0.0:3010", handler); err != nil {
+		log.Fatalf("There was an error with the http server: %v", err)
 	}
-
-	const scopeKey = "scope"
-	tokenScope, ok := claims[scopeKey].(string)
-	if !ok {
-		return false
-	}
-
-	result := strings.Split(tokenScope, " ")
-	for i := range result {
-		if result[i] == scope {
-			return true
-		}
-	}
-
-	return false
-}
-
-func getPemCert(token *jwt.Token) (string, error) {
-	cert := ""
-	resp, err := http.Get("https://" + os.Getenv("AUTH0_DOMAIN") + "/.well-known/jwks.json")
-
-	if err != nil {
-		return cert, err
-	}
-	defer resp.Body.Close()
-
-	var jwks = Jwks{}
-	err = json.NewDecoder(resp.Body).Decode(&jwks)
-
-	if err != nil {
-		return cert, err
-	}
-
-	for k, _ := range jwks.Keys {
-		if token.Header["kid"] == jwks.Keys[k].Kid {
-			cert = "-----BEGIN CERTIFICATE-----\n" + jwks.Keys[k].X5c[0] + "\n-----END CERTIFICATE-----"
-		}
-	}
-
-	if cert == "" {
-		err := errors.New("Unable to find appropriate key.")
-		return cert, err
-	}
-
-	return cert, nil
-}
-
-func responseJSON(message string, w http.ResponseWriter, statusCode int) {
-	response := Response{message}
-
-	jsonResponse, err := json.Marshal(response)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(statusCode)
-	w.Write(jsonResponse)
 }

--- a/01-Authorization-RS256/middleware/jwt.go
+++ b/01-Authorization-RS256/middleware/jwt.go
@@ -1,0 +1,77 @@
+package middleware
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"os"
+
+	"github.com/auth0/go-jwt-middleware"
+	"github.com/form3tech-oss/jwt-go"
+)
+
+var JWT = jwtmiddleware.New(jwtmiddleware.Options{
+	ValidationKeyGetter: func(token *jwt.Token) (interface{}, error) {
+		// Verify 'aud' claim
+		aud := os.Getenv("AUTH0_AUDIENCE")
+		checkAud := token.Claims.(jwt.MapClaims).VerifyAudience(aud, false)
+		if !checkAud {
+			return token, errors.New("invalid audience")
+		}
+
+		// Verify 'iss' claim
+		iss := "https://" + os.Getenv("AUTH0_DOMAIN") + "/"
+		checkIss := token.Claims.(jwt.MapClaims).VerifyIssuer(iss, false)
+		if !checkIss {
+			return token, errors.New("invalid issuer")
+		}
+
+		cert, err := getPemCert(token)
+		if err != nil {
+			return token, err
+		}
+
+		return jwt.ParseRSAPublicKeyFromPEM([]byte(cert))
+	},
+	SigningMethod: jwt.SigningMethodRS256,
+})
+
+type Jwks struct {
+	Keys []JSONWebKeys `json:"keys"`
+}
+
+type JSONWebKeys struct {
+	Kty string   `json:"kty"`
+	Kid string   `json:"kid"`
+	Use string   `json:"use"`
+	N   string   `json:"n"`
+	E   string   `json:"e"`
+	X5c []string `json:"x5c"`
+}
+
+func getPemCert(token *jwt.Token) (string, error) {
+	resp, err := http.Get("https://" + os.Getenv("AUTH0_DOMAIN") + "/.well-known/jwks.json")
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	var jwks Jwks
+	if err = json.NewDecoder(resp.Body).Decode(&jwks); err != nil {
+		return "", err
+	}
+
+	var cert string
+	for _, key := range jwks.Keys {
+		if token.Header["kid"] == key.Kid {
+			cert = "-----BEGIN CERTIFICATE-----\n" + key.X5c[0] + "\n-----END CERTIFICATE-----"
+			break
+		}
+	}
+
+	if cert == "" {
+		return cert, errors.New("unable to find appropriate key")
+	}
+
+	return cert, nil
+}

--- a/01-Authorization-RS256/router/router.go
+++ b/01-Authorization-RS256/router/router.go
@@ -1,0 +1,98 @@
+package router
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/codegangsta/negroni"
+	"github.com/form3tech-oss/jwt-go"
+	"github.com/gorilla/mux"
+
+	"01-Authorization-RS256/middleware"
+)
+
+type Response struct {
+	Message string `json:"message"`
+}
+
+func New() *mux.Router {
+	r := mux.NewRouter()
+
+	// This route is always accessible
+	r.Handle("/api/public", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		message := "Hello from a public endpoint! You don't need to be authenticated to see this."
+		responseJSON(message, w, http.StatusOK)
+	}))
+
+	// This route is only accessible if the user has a valid access_token
+	// We are chaining the jwtmiddleware middleware into the negroni handler function which will check
+	// for a valid token.
+	r.Handle("/api/private", negroni.New(
+		negroni.HandlerFunc(middleware.JWT.HandlerWithNext),
+		negroni.Wrap(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			message := "Hello from a private endpoint! You need to be authenticated to see this."
+			responseJSON(message, w, http.StatusOK)
+		}))))
+
+	// This route is only accessible if the user has a valid access_token with the read:messages scope
+	// We are chaining the jwtmiddleware middleware into the negroni handler function which will check
+	// for a valid token and scope.
+	r.Handle(
+		"/api/private-scoped",
+		negroni.New(
+			negroni.HandlerFunc(middleware.JWT.HandlerWithNext),
+			negroni.Wrap(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				token := r.Context().Value("user").(*jwt.Token)
+
+				hasScope := checkScope("read:messages", token)
+				if !hasScope {
+					message := "Insufficient scope."
+					responseJSON(message, w, http.StatusForbidden)
+					return
+				}
+
+				message := "Hello from a private endpoint! You need to be authenticated to see this."
+				responseJSON(message, w, http.StatusOK)
+			})),
+		),
+	)
+
+	return r
+}
+
+func checkScope(scope string, token *jwt.Token) bool {
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return false
+	}
+
+	const scopeKey = "scope"
+	tokenScope, ok := claims[scopeKey].(string)
+	if !ok {
+		return false
+	}
+
+	result := strings.Split(tokenScope, " ")
+	for i := range result {
+		if result[i] == scope {
+			return true
+		}
+	}
+
+	return false
+}
+
+func responseJSON(message string, w http.ResponseWriter, statusCode int) {
+	response := Response{message}
+
+	jsonResponse, err := json.Marshal(response)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	w.Write(jsonResponse)
+}


### PR DESCRIPTION
## Ticket: SDK-2848

## Description

In this PR we break the code in main down into multiple packages:
- middleware
- router

Leaving the functionality untouched. This is in preparation of additional improvements and dependency swaps so that we make sure the changes will be more isolated. 